### PR TITLE
Copy user-provider args over to env for param population

### DIFF
--- a/pr-comment-filter/main.go
+++ b/pr-comment-filter/main.go
@@ -205,19 +205,13 @@ func main() {
 			},
 		}
 
-		// Populate params with PR details
-		for key, val := range env {
-			pipelineRun.Spec.Params = append(pipelineRun.Spec.Params, tkn.Param{
-				Name: key,
-				Value: tkn.ParamValue{
-					Type:      tkn.ParamTypeString,
-					StringVal: val,
-				},
-			})
+		// Copy Args over to `env` object for populating params
+		for key, val := range trigger.Args {
+			env[key] = val
 		}
 
-		// Populate params with trigger args
-		for key, val := range trigger.Args {
+		// Populate params with PR details
+		for key, val := range env {
 			pipelineRun.Spec.Params = append(pipelineRun.Spec.Params, tkn.Param{
 				Name: key,
 				Value: tkn.ParamValue{


### PR DESCRIPTION
To be able to override values (e.g. `GIT_REVISION`) with user-provided values we need to replace the existing values in the `env` object so we don't end up with the same param name used twice (which is blocked by the admission webhook).