### PR TITLE
Support using positional args in /run triggers

### DIFF
--- a/pr-comment-filter/README.md
+++ b/pr-comment-filter/README.md
@@ -19,13 +19,17 @@ Examples:
 /run test-cluster-create PRIVATE_NETWORK=true
 /run test-cluster-create PREVIOUS_VERSION=1.2.6
 /run test-cluster-upgrade PRIVATE_NETWORK=false PREVIOUS_VERSION=1.2.6
+/run hold wait-for-tests
+/run help NAMESPACE=foo-bar test-cluster-create
 ```
 
 Some notes:
 
 * Multiple triggers can be defined in a single comment but must each be on their own line
 * Triggers must start the line with `/run ` and cannot be placed mid-sentance
-* Arguments are optional and in the format of `KEY=value` where the key must be all uppercase
+* Arguments are optional and in the format of either:
+  * `KEY=value` where the key must be all uppercase and is used as the key/val pair of environment variables
+  * space seperated words - these are treated as "positional arguments" and added as the `POS_ARGS` env var with the values comma seperated
 * Multiple arguments can be provided as long as they all appear on the same line as the trigger
 * Argument values with spaces in them is not currently supported
 * A Pipeline from a specific namespace can be run by specifying a `NAMESPACE=xxx` argument along with the `/run` trigger line


### PR DESCRIPTION
Allows for providing more flexible variables passed to `/run` triggers. 

Example use case: `/run help generate-mc-all`

Related: https://github.com/giantswarm/giantswarm/issues/27372